### PR TITLE
Pass the actually bound port back to the client.

### DIFF
--- a/java/de/ofahrt/catfish/internal/network/NetworkEngine.java
+++ b/java/de/ofahrt/catfish/internal/network/NetworkEngine.java
@@ -557,7 +557,7 @@ public final class NetworkEngine {
 
             @Override
             public int port() {
-              return port;
+              return serverChannel.socket().getLocalPort();
             }
 
             @Override


### PR DESCRIPTION
This allows passing a port of 0 to bind any available port. That is useful for test writing.