### PR TITLE
SimpleHttpRequest: rewrite error handling in builder

### DIFF
--- a/javatest/de/ofahrt/catfish/api/SimpleHttpRequestTest.java
+++ b/javatest/de/ofahrt/catfish/api/SimpleHttpRequestTest.java
@@ -2,40 +2,104 @@ package de.ofahrt.catfish.api;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertThrows;
 
-import org.junit.Test;
+import de.ofahrt.catfish.model.HttpHeaderName;
 import de.ofahrt.catfish.model.HttpMethodName;
 import de.ofahrt.catfish.model.HttpStatusCode;
 import de.ofahrt.catfish.model.HttpVersion;
 import de.ofahrt.catfish.model.MalformedRequestException;
 import de.ofahrt.catfish.model.SimpleHttpRequest;
+import org.junit.Test;
 
 public class SimpleHttpRequestTest {
-
   @Test
-  public void noHostOnHttp11RequestResultsIn400() throws Exception {
-    try {
-      new SimpleHttpRequest.Builder()
-          .setVersion(HttpVersion.HTTP_1_1)
-          .setMethod(HttpMethodName.GET)
-          .setUri("/")
-          .build();
-      fail();
-    } catch (MalformedRequestException e) {
-      assertEquals(HttpStatusCode.BAD_REQUEST.getStatusCode(), e.getErrorResponse().getStatusCode());
-    }
+  public void missingUri() {
+    var e =
+        assertThrows(
+            MalformedRequestException.class,
+            () ->
+                new SimpleHttpRequest.Builder()
+                    .setVersion(HttpVersion.HTTP_1_1)
+                    .setMethod(HttpMethodName.GET)
+                    .build());
+    assertEquals(HttpStatusCode.BAD_REQUEST.getStatusCode(), e.getErrorResponse().getStatusCode());
+    assertNotNull(e.getErrorResponse().getBody());
   }
 
   @Test
-  public void simpleErrorAlwaysContainsEmptyBody() throws Exception {
-    try {
-      new SimpleHttpRequest.Builder()
-          .setError(HttpStatusCode.BAD_REQUEST, "foobar")
-          .build();
-      fail();
-    } catch (MalformedRequestException e) {
-      assertNotNull(e.getErrorResponse().getBody());
-    }
+  public void noHostOnHttp11RequestResultsIn400() {
+    var e =
+        assertThrows(
+            MalformedRequestException.class,
+            () ->
+                new SimpleHttpRequest.Builder()
+                    .setVersion(HttpVersion.HTTP_1_1)
+                    .setMethod(HttpMethodName.GET)
+                    .setUri("/")
+                    .build());
+    assertEquals(HttpStatusCode.BAD_REQUEST.getStatusCode(), e.getErrorResponse().getStatusCode());
+    assertNotNull(e.getErrorResponse().getBody());
+  }
+
+  @Test
+  public void simpleErrorAlwaysContainsEmptyBody() {
+    var e =
+        assertThrows(
+            MalformedRequestException.class,
+            () ->
+                new SimpleHttpRequest.Builder()
+                    .setError(HttpStatusCode.BAD_REQUEST, "foobar")
+                    .build());
+    assertEquals(HttpStatusCode.BAD_REQUEST.getStatusCode(), e.getErrorResponse().getStatusCode());
+    assertNotNull(e.getErrorResponse().getBody());
+  }
+
+  @Test
+  public void mustHaveBodyWithTransferEncoding() {
+    var e =
+        assertThrows(
+            MalformedRequestException.class,
+            () ->
+                new SimpleHttpRequest.Builder()
+                    .setVersion(HttpVersion.HTTP_1_1)
+                    .setMethod(HttpMethodName.GET)
+                    .setUri("/")
+                    .addHeader(HttpHeaderName.HOST, "localhost")
+                    .addHeader(HttpHeaderName.TRANSFER_ENCODING, "gzip")
+                    .build());
+    assertEquals(HttpStatusCode.BAD_REQUEST.getStatusCode(), e.getErrorResponse().getStatusCode());
+    assertNotNull(e.getErrorResponse().getBody());
+  }
+
+  @Test
+  public void mustHaveBodyWithContentLength() {
+    var e =
+        assertThrows(
+            MalformedRequestException.class,
+            () ->
+                new SimpleHttpRequest.Builder()
+                    .setVersion(HttpVersion.HTTP_1_1)
+                    .setMethod(HttpMethodName.GET)
+                    .setUri("/")
+                    .addHeader(HttpHeaderName.HOST, "localhost")
+                    .addHeader(HttpHeaderName.CONTENT_LENGTH, "1234")
+                    .build());
+    assertEquals(HttpStatusCode.BAD_REQUEST.getStatusCode(), e.getErrorResponse().getStatusCode());
+    assertNotNull(e.getErrorResponse().getBody());
+  }
+
+  @Test
+  public void validRequest() throws MalformedRequestException {
+    var request =
+        new SimpleHttpRequest.Builder()
+            .setVersion(HttpVersion.HTTP_1_1)
+            .setMethod(HttpMethodName.GET)
+            .setUri("/")
+            .addHeader(HttpHeaderName.HOST, "localhost")
+            .build();
+    assertEquals("GET", request.getMethod());
+    assertEquals(HttpVersion.HTTP_1_1, request.getVersion());
+    assertEquals("/", request.getUri());
   }
 }

--- a/javatest/de/ofahrt/catfish/bridge/RequestImplTest.java
+++ b/javatest/de/ofahrt/catfish/bridge/RequestImplTest.java
@@ -34,7 +34,7 @@ public class RequestImplTest {
         null);
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test(expected = MalformedRequestException.class)
   public void missingUri() throws MalformedRequestException {
     new SimpleHttpRequest.Builder().build();
   }


### PR DESCRIPTION
Specifically, check for errors in a certain order and always throw `MalformedRequestException` instead of `IllegalStateException`.